### PR TITLE
Return different writable streams depending on whether writing without response is permitted

### DIFF
--- a/src/transport/gatt.ts
+++ b/src/transport/gatt.ts
@@ -54,16 +54,16 @@ export async function connect(): Promise<RpcTransport> {
 
   return { label, readable,
     writable: char.properties.writeWithoutResponse ?
-    new WritableStream({
-      write(chunk) {
-        return char.writeValueWithoutResponse(chunk);
-      },
-    })
-    :
-    new WritableStream({
-      write(chunk) {
-        return char.writeValueWithResponse(chunk);
-      },
-    })
+      new WritableStream({
+        write(chunk) {
+          return char.writeValueWithoutResponse(chunk);
+        },
+      })
+      :
+      new WritableStream({
+        write(chunk) {
+          return char.writeValueWithResponse(chunk);
+        },
+      })
   };
 }

--- a/src/transport/gatt.ts
+++ b/src/transport/gatt.ts
@@ -52,18 +52,18 @@ export async function connect(): Promise<RpcTransport> {
     },
   });
 
-  let writableWithoutResponse = new WritableStream({
-    write(chunk) {
-      return char.writeValueWithoutResponse(chunk);
-    },
-  });
-
-  let writableWithResponse = new WritableStream({
-    write(chunk) {
-      return char.writeValueWithResponse(chunk);
-    },
-  });
-
   return { label, readable,
-           writable: char.properties.writeWithoutResponse ? writableWithoutResponse : writableWithResponse };
+    writable: char.properties.writeWithoutResponse ?
+    new WritableStream({
+      write(chunk) {
+        return char.writeValueWithoutResponse(chunk);
+      },
+    })
+    :
+    new WritableStream({
+      write(chunk) {
+        return char.writeValueWithResponse(chunk);
+      },
+    })
+  };
 }


### PR DESCRIPTION
When constructing a new transport, it seems that on some systems writing without a response is not permitted (based on the writeWithoutResponse property: https://developer.mozilla.org/en-US/docs/Web/API/BluetoothCharacteristicProperties).

This PR retains the current default behavior (without response) for boards that support it, but adds support for boards where this is not enabled.