### PR TITLE
feat: pass serial port request options during connection

### DIFF
--- a/src/transport/serial.ts
+++ b/src/transport/serial.ts
@@ -1,6 +1,6 @@
 import type { RpcTransport } from './';
 
-export async function connect(options: SerialPortRequestOptions): Promise<RpcTransport> {
+export async function connect(options?: SerialPortRequestOptions): Promise<RpcTransport> {
   let abortController = new AbortController();
   let port = await navigator.serial.requestPort(options);
 

--- a/src/transport/serial.ts
+++ b/src/transport/serial.ts
@@ -1,8 +1,8 @@
 import type { RpcTransport } from './';
 
-export async function connect(): Promise<RpcTransport> {
+export async function connect(options: SerialPortRequestOptions): Promise<RpcTransport> {
   let abortController = new AbortController();
-  let port = await navigator.serial.requestPort({});
+  let port = await navigator.serial.requestPort(options);
 
   await port.open({ baudRate: 12500 })
         .catch((e) => {


### PR DESCRIPTION
I’d like to enhance the connect() function by allowing users to optionally pass in SerialPortRequestOptions. 

This would enable us to specify VID/PID filters when initiating a connection, refining the list of available serial devices for selection. 

By narrowing down the options, we can streamline the user experience, making it easier and more intuitive to choose the correct device (where possible)